### PR TITLE
add redirection support

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,8 @@
     <title>{% if page.title %}{{ page.title }} – {% endif %}{{ site.name }} – {{ site.description }}</title>
 
     <meta name="author" content="{{ site.name }}" />
-    <meta name="description" content="{{ site.description }}">
+    <meta name="description" content="{{ site.description }}"
+    {% if page.redirection %}<meta http-equiv="refresh" content="0; url={{ page.redirect-to }}">{% endif %}
 
     <!--[if lt IE 9]>
       <script src="http://html5shiv.googlecode.com/svn/trunk/html5.js"></script>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -8,7 +8,7 @@
     <title>{% if page.title %}{{ page.title }} – {% endif %}{{ site.name }} – {{ site.description }}</title>
 
     <meta name="author" content="{{ site.name }}" />
-    <meta name="description" content="{{ site.description }}"
+    <meta name="description" content="{{ site.description }}">
     {% if page.redirection %}<meta http-equiv="refresh" content="0; url={{ page.redirect-to }}">{% endif %}
 
     <!--[if lt IE 9]>


### PR DESCRIPTION
Enable users to redirect their posts to external URLs in case they write a post on any site other than their blog but want it to be on their blog too.
Users have to to simply put this in their YAML front matter-

<pre>

---
redirection: true
redirect-to: http://example.com/POST-URL

---
</pre>


And as someone opens the post on the blog, it's immediately redirected to the the URL described in the YAML.
